### PR TITLE
added dest file name

### DIFF
--- a/devops/ansible/roles/nifi_install/tasks/install_nifi.yml
+++ b/devops/ansible/roles/nifi_install/tasks/install_nifi.yml
@@ -13,7 +13,7 @@
 - name: Download NiFi
   get_url:
     url: https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.tar.gz
-    dest: ~/nifi
+    dest: ~/nifi/nifi-{{ nifi_version }}-bin.tar.gz
     mode: "0644"
   tags: install
 


### PR DESCRIPTION
nifi download task timeouts and every time it's downloading the file even if it already exists. (the file size is almost 1.5G grinning )

So I have added the dest file name to avoid re-downloading the file f it already exists

Fix for: https://github.com/Sunbird-cQube/cQube_Edu/issues/587

